### PR TITLE
Shift codepoint indices when trimming data from front

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -227,9 +227,18 @@ func rawValueFromLine(value rawValue, startPos, endPos int, format format) rawVa
 			relevantIndices = value.codepointIndices[startPos-1 : endPos]
 			lineData = value.data[relevantIndices[0]:value.codepointIndices[endPos]]
 		}
+
+		// We trimmed data from the front of the string.
+		// We need to adjust the codepoint indices to reflect this, as they have shifted.
+		removedFromFront := relevantIndices[0]
+		newIndices := make([]int, 0, len(relevantIndices))
+		for _, idx := range relevantIndices {
+			newIndices = append(newIndices, idx-removedFromFront)
+		}
+
 		return rawValue{
 			data:             trimFunc(lineData),
-			codepointIndices: relevantIndices,
+			codepointIndices: newIndices,
 		}
 	} else {
 		if len(value.data) == 0 || startPos > len(value.data) {


### PR DESCRIPTION
These codepoint indices are now invalid when trimming data from the front of the string. Shift these left to match the new byte offsets after trim.

Fixes potential panic or invalid data when using UTF-8 encoded strings with nested struct members.